### PR TITLE
Shebang should be bash since the script is bash 

### DIFF
--- a/usr/bin/gamescope-session
+++ b/usr/bin/gamescope-session
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usb/bin/env bash
 
 # Some environment variables by default (taken from Deck session)
 export SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS=0

--- a/usr/bin/gamescope-session
+++ b/usr/bin/gamescope-session
@@ -1,4 +1,4 @@
-#!/usb/bin/env bash
+#!/usr/bin/env bash
 
 # Some environment variables by default (taken from Deck session)
 export SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS=0


### PR DESCRIPTION
The script uses bash-isms that are incompatible with POSIX shell. Examples; `[[`, `+=`, `read -t`.

This is easily verifiable by running the script with `dash`.

This can of course be fixed in two ways:

1. Make `bash` a dependency and set the shebang to `bash`.
2. Remove all bash-isms and make it POSIX compliant.

Option 1 is the easiest and not unreasonable in my opinion.