### PR TITLE
Fix mangoapp launch syntax error.

### DIFF
--- a/usr/bin/gamescope-session
+++ b/usr/bin/gamescope-session
@@ -156,7 +156,7 @@ fi
 
 # If we have mangoapp binary start it
 if command -v mangoapp > /dev/null; then
-    mangoapp & > "${HOME}"/.mangoapp-stdout.log 2>&1
+    mangoapp > "${HOME}"/.mangoapp-stdout.log 2>&1 &
 fi
 
 # Start Steam client


### PR DESCRIPTION
This line launched `mangoapp` in the background and redirects nothing to `.mangoapp-stdout.log`.

The correct way is to redirect first and start process after.

Verified that nothing was being written to `.mangoapp-stdout.log` and output does after change.

See: https://unix.stackexchange.com/questions/74520/can-i-redirect-output-to-a-log-file-and-background-a-process-at-the-same-time 