### PR TITLE
Added --prefer-vk-device IDs for a model of the Zephryus G14 laptop.

### DIFF
--- a/usr/share/gamescope-session/device-quirks
+++ b/usr/share/gamescope-session/device-quirks
@@ -28,3 +28,16 @@ if [ "$(cat /sys/devices/virtual/dmi/id/product_name)" == "AIR" ] || [ "$(cat /s
       --force-orientation left "
   fi
 fi
+
+if [ "$(cat /sys/devices/virtual/dmi/id/product_name)" == "ROG Zephyrus G14 GA402RJ_GA402RJ" ]; then
+  export GAMESCOPECMD="/usr/bin/gamescope \
+      -e \
+      --xwayland-count 2 \
+      -O \'\*\',eDP-1 \
+      --default-touch-mode 4 \
+      --hide-cursor-delay 3000 \
+# uncomment the line below to enable 6700s discreet graphics and # the line with 1002:1681 to disable integrated graphics
+#     --prefer-vk-device 1002:73ef "
+      --prefer-vk-device 1002:1681 "
+fi
+


### PR DESCRIPTION
This will target the 680M graphics so that the laptop will successfully boot into ChimeraOS.