### PR TITLE
Add generate-drm-mode to fix refresh changing on OXP devices.

### DIFF
--- a/usr/share/gamescope-session/device-quirks
+++ b/usr/share/gamescope-session/device-quirks
@@ -10,6 +10,7 @@ if [[ ":$OXP_LIST:" =~ ":$SYS_ID:"  ]]; then
   if ( gamescope --help 2>&1 | grep -e "--force-orientation" > /dev/null ) ; then
     export GAMESCOPECMD="/usr/bin/gamescope \
       -e \
+      --generate-drm-mode fixed \
       --xwayland-count 2 \
       -O \'\*\',eDP-1 \
       --default-touch-mode 4 \


### PR DESCRIPTION
With updated bios this should be fully functional, with un-patched bios the range is much greater and 40hz mostly works.