### PR TITLE
Finally fix intel xwayland issues

### DIFF
--- a/usr/share/gamescope-session/gamescope-session-script
+++ b/usr/share/gamescope-session/gamescope-session-script
@@ -4,6 +4,7 @@
 # might come with some performance degradation but is better than a corrupted
 # color image
 export INTEL_DEBUG=norbc
+export mesa-glthread=true
 
 # Some environment variables by default (taken from Deck session)
 export SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS=0


### PR DESCRIPTION
This fixes the issues for mesa 22.3.5+ as well as the devices that were broke such as the Intel OneXplayer when using `xwayland-count 2`