### PR TITLE
Setting GPD Win 3 orientation to "normal"

### DIFF
--- a/usr/share/gamescope-session/device-quirks
+++ b/usr/share/gamescope-session/device-quirks
@@ -40,7 +40,7 @@ if [[ ":$AIR_LIST:" =~ ":$SYS_ID:"  ]]; then
 fi
 
 # GDP Win devices
-GDP_LIST="G1618-03:G1619-01:G1621-02:MicroPC"
+GDP_LIST="G1619-01:G1621-02:MicroPC"
 if [[ ":$GDP_LIST:" =~ ":$SYS_ID:"  ]]; then
   # Dependent on a special --force-orientation option in gamescope
   if ( gamescope --help 2>&1 | grep -e "--force-orientation" > /dev/null ) ; then
@@ -53,5 +53,22 @@ if [[ ":$GDP_LIST:" =~ ":$SYS_ID:"  ]]; then
       --hide-cursor-delay 3000 \
       --fade-out-duration 200 \
       --force-orientation right "
+  fi
+  
+  # GPD Win 3 specifc quirk to prevent crashing
+  # The GPD Win 3 does not support hardware rotation for 270/90 modes. We need to implement shader rotations to get this working correctly.
+  # 0/180 rotations should work.
+if [[ ":G1618-03:" =~ ":$SYS_ID:"  ]]; then
+  # Dependent on a special --force-orientation option in gamescope
+  if ( gamescope --help 2>&1 | grep -e "--force-orientation" > /dev/null ) ; then
+    export GAMESCOPECMD="/usr/bin/gamescope \
+      -e \
+      --generate-drm-mode fixed \
+      --xwayland-count 2 \
+      -O *,DSI-1 \
+      --default-touch-mode 4 \
+      --hide-cursor-delay 3000 \
+      --fade-out-duration 200 \
+      --force-orientation normal "
   fi
 fi


### PR DESCRIPTION
The hardware is not compatible with 90/270 rotations so it will cause a loop. We need to implement shader rotations in gamescope to resolve this issue.