### PR TITLE
Fixes display on air not working until returning from sleep while also enabling scaling for readability.

### DIFF
--- a/usr/share/gamescope-session/device-quirks
+++ b/usr/share/gamescope-session/device-quirks
@@ -13,18 +13,18 @@ OXP_LIST="ONE XPLAYER:ONEXPLAYER 1 T08:ONEXPLAYER 1S A08:ONEXPLAYER 1S T08:ONEXP
 AOK_LIST="AOKZOE A1 AR07:AOKZOE A1 Pro"
 if [[ ":$OXP_LIST:" =~ ":$SYS_ID:"  ]] || [[  ":$AOK_LIST:" =~ ":$SYS_ID:"   ]]; then
   # Intel support is extremely experimental, this is the bare minimum to get the system to boot.
-  # Dependent on a special --force-orientation option in gamescope
+  # Dependent on a special --force-external-orientation option in gamescope
   if ( gamescope --help 2>&1 | grep -e "--force-external-orientation" > /dev/null ) &&  [[ "$CPU_VENDOR" =~ "GenuineIntel" ]]; then
-      export GAMESCOPECMD="/usr/bin/gamescope \
-        -e \
-        --generate-drm-mode fixed \
-        --xwayland-count 2 \
-        -O *,eDP-1 \
-        --default-touch-mode 4 \
-        --hide-cursor-delay 3000 \
-        --fade-out-duration 200 \
-        --force-panel-type external \
-        --force-external-orientation left "
+    export GAMESCOPECMD="/usr/bin/gamescope \
+      -e \
+      --generate-drm-mode fixed \
+      --xwayland-count 2 \
+      -O *,eDP-1 \
+      --default-touch-mode 4 \
+      --hide-cursor-delay 3000 \
+      --fade-out-duration 200 \
+      --force-panel-type external \
+      --force-external-orientation left "
   # AMD Support and fallback for users of gamescope-git.
   elif ( gamescope --help 2>&1 | grep -e "--force-orientation" > /dev/null ) ; then
     export GAMESCOPECMD="/usr/bin/gamescope \
@@ -44,8 +44,19 @@ fi
 # AYANEO AIR Devices
 AIR_LIST="AIR:AIR Pro:AIR Plus"
 if [[ ":$AIR_LIST:" =~ ":$SYS_ID:"  ]]; then
-  # Dependent on a special --force-orientation option in gamescope
-  if ( gamescope --help 2>&1 | grep -e "--force-orientation" > /dev/null ) ; then
+  # Dependent on a special --force-external-orientation option in gamescope
+  if ( gamescope --help 2>&1 | grep -e "--force-external-orientation" > /dev/null ) ; then
+    export GAMESCOPECMD="/usr/bin/gamescope \
+      -e \
+      --xwayland-count 2 \
+      -O *,eDP-1 \
+      --default-touch-mode 4 \
+      --hide-cursor-delay 3000 \
+      --fade-out-duration 200 \
+      --force-panel-type external
+      --force-external-orientation left "
+  # Fallback method. Dependent on a special --force-orientation option in gamescope
+  elif ( gamescope --help 2>&1 | grep -e "--force-orientation" > /dev/null ) ; then
     export GAMESCOPECMD="/usr/bin/gamescope \
       -e \
       --xwayland-count 2 \


### PR DESCRIPTION
While at it, fix indent on OXP section.