### PR TITLE
Add script to be used with a systemd service to handle the ICD of Nvi…

### DIFF
--- a/usr/share/gamescope-session/check-nvidia.sh
+++ b/usr/share/gamescope-session/check-nvidia.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if /usr/bin/lspci | grep -i nvidia; then
+  if [ -f /usr/share/vulkan/icd.d/nvidia_icd.json.bak ]; then
+    mv /usr/share/vulkan/icd.d/nvidia_icd.json.bak /usr/share/vulkan/icd.d/nvidia_icd.json
+  fi
+else
+  if [ -f /usr/share/vulkan/icd.d/nvidia_icd.json ]; then
+    mv /usr/share/vulkan/icd.d/nvidia_icd.json /usr/share/vulkan/icd.d/nvidia_icd.json.bak
+  fi
+fi
+


### PR DESCRIPTION
Having the Nvidia driver installed causes issues for non-nvidia hardware that can break games completely or cause very long boot times when using proton. We tried exporting the environment variables after filtering out Nvidia, but this gave us other serious problems where flatpaks and appimages broke. As hacky as this is this might be the best option we have outside of dropping Nvidia support entirely.