### PR TITLE
Fixed typos and grammatical errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Steam Big Picture Mode session based on Valve's [`gamescope`](https://github.com/Plagman/gamescope)
 
 This project is not affiliated with Valve (wide inspiration was taken from
-their work on the Steam Deck) and is part of the ChimeraOS project. Regardless
-is generic enough and aims to be usable on any distribution. If you have any
-issues with it, just report them on teh issue tracker.
+their work on the Steam Deck) and is part of the ChimeraOS project. Regardless,
+it is generic enough and aims to be usable on any distribution. If you have any
+issues with it, just report them on the issue tracker.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Steam Big Picture Mode session based on Valve's [`gamescope`](https://github.com/Plagman/gamescope)
 
 This project is not affiliated with Valve (wide inspiration was taken from
-their work on teh SteamDeck) and is part of the ChimeraOS project. Regardless
+their work on the Steam Deck) and is part of the ChimeraOS project. Regardless
 is generic enough and aims to be usable on any distribution. If you have any
 issues with it, just report them on teh issue tracker.
 


### PR DESCRIPTION
Hello.

There was a small typo in the README. I also added a space to "SteamDeck", which I think would be the correct way to spell it.