### PR TITLE
add Lenovo Legion Go display to device quirks

### DIFF
--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -204,3 +204,31 @@ if [[ ":ROG Ally RC71L_RC71L:" =~ ":$SYS_ID:"  ]]; then
   # Set refresh rate range and enable refresh rate switching
   export STEAM_DISPLAY_REFRESH_LIMITS=40,120
 fi
+
+# Lenovo Legion Go
+if [[ ":83E1:" =~ ":$SYS_ID:"  ]]; then
+  # Dependent on a special --force-panel-type option in gamescope-plus
+  if ( gamescope --help 2>&1 | grep -e "--force-panel-type" > /dev/null ) ; then
+    export GAMESCOPECMD="/usr/bin/gamescope \
+      -e \
+      --xwayland-count 2 \
+      -O *,eDP-1 \
+      --default-touch-mode 4 \
+      --hide-cursor-delay 3000 \
+      --fade-out-duration 200 \
+      --adaptive-sync \
+      --force-orientation left "
+  # fallback for users of gamescope-git.
+  elif ( gamescope --help 2>&1 | grep -e "--force-orientation" > /dev/null ) ; then
+    export GAMESCOPECMD="/usr/bin/gamescope \
+      -e \
+      --xwayland-count 2 \
+      -O *,eDP-1 \
+      --default-touch-mode 4 \
+      --hide-cursor-delay 3000 \
+      --fade-out-duration 200 "
+  fi
+  # Set refresh rate range and enable refresh rate switching
+  export STEAM_DISPLAY_REFRESH_LIMITS=60,144
+fi
+


### PR DESCRIPTION
Lenovo Legion Go displays upside down, needs a device quirk :clinking_glasses: 

![F90XlZwWcAA2tWz](https://github.com/ChimeraOS/gamescope-session/assets/11287837/f665d08c-ae9a-42d3-86c5-924e703deb07)
