### PR TITLE
Fix gamescope param check for Legion Go

### DIFF
--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -207,8 +207,7 @@ fi
 
 # Lenovo Legion Go
 if [[ ":83E1:" =~ ":$SYS_ID:"  ]]; then
-  # Dependent on a special --force-panel-type option in gamescope-plus
-  if ( gamescope --help 2>&1 | grep -e "--force-panel-type" > /dev/null ) ; then
+  if ( gamescope --help 2>&1 | grep -e "--force-orientation" > /dev/null ) ; then
     export GAMESCOPECMD="/usr/bin/gamescope \
       -e \
       --xwayland-count 2 \
@@ -218,15 +217,6 @@ if [[ ":83E1:" =~ ":$SYS_ID:"  ]]; then
       --fade-out-duration 200 \
       --adaptive-sync \
       --force-orientation left "
-  # fallback for users of gamescope-git.
-  elif ( gamescope --help 2>&1 | grep -e "--force-orientation" > /dev/null ) ; then
-    export GAMESCOPECMD="/usr/bin/gamescope \
-      -e \
-      --xwayland-count 2 \
-      -O *,eDP-1 \
-      --default-touch-mode 4 \
-      --hide-cursor-delay 3000 \
-      --fade-out-duration 200 "
   fi
   # Set refresh rate range and enable refresh rate switching
   export STEAM_DISPLAY_REFRESH_LIMITS=60,144


### PR DESCRIPTION
Old version checked for panel type param it didn't use. Broke gamescope git.