### PR TITLE
Add env variable OUTPUT_CONNECTOR

### DIFF
--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -130,6 +130,9 @@ if [ -f "$CURSOR_FILE" ] ; then
     CURSOR="--cursor ${CURSOR_FILE}"
 fi
 
+# Use specified output connector(s) if set, otherwise use default value
+: "${OUTPUT_CONNECTOR:=*,eDP-1}"
+
 if [ -z "$GAMESCOPECMD" ] ; then
     RESOLUTION=""
     if [ -n "$SCREEN_WIDTH" ] && [ -n "$SCREEN_HEIGHT" ] ; then
@@ -142,7 +145,7 @@ if [ -z "$GAMESCOPECMD" ] ; then
         -e \
         $RESOLUTION \
         --xwayland-count 2 \
-        -O *,eDP-1 \
+        -O $OUTPUT_CONNECTOR \
         --default-touch-mode 4 \
         --hide-cursor-delay 3000 \
         --fade-out-duration 200 \
@@ -153,7 +156,7 @@ if [ -z "$GAMESCOPECMD" ] ; then
         -e \
         $RESOLUTION \
         --xwayland-count 2 \
-        -O *,eDP-1 \
+        -O $OUTPUT_CONNECTOR \
         --default-touch-mode 4 \
         --hide-cursor-delay 3000 \
         --fade-out-duration 200 \


### PR DESCRIPTION
As the title says, this PR adds an environment variable named OUTPUT_CONNECTOR which lets the user specify their output preference.

As per gamescope docs: Accepts a single connector (e.g. "DP-1") or multiple comma-separated connectors (e.g. "DP-1, DP-3"). Note that this does not mean simultaneous output, but is just an output order preference (-> output to DP-3 if DP-1 not available).

I initially thought that the variable should be named something like OUTPUT_CONNECTORS, but I figured that most people would only pass one preferred output anyways. Of course we have the option to exchange the whole gamescope command via GAMESCOPECMD, but I think setting the output is as basic as setting e.g. the resolution, especially on desktop PCs with multiple monitors.