### PR TITLE
Change panel type from external to internal for Ayn Loki devices

### DIFF
--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -97,7 +97,7 @@ fi
 AYN_LIST="Loki Max:Loki Zero:Loki MiniPro"
 if [[ ":$AYN_LIST:" =~ ":$SYS_ID:"  ]]; then
   # Dependent on a special --force-external-orientation option in gamescope
-  if ( gamescope --help 2>&1 | grep -e "--force-external-orientation" > /dev/null ) ; then
+  if ( gamescope --help 2>&1 | grep -e "--force-orientation" > /dev/null ) ; then
     export GAMESCOPECMD="/usr/bin/gamescope \
       -e \
       --generate-drm-mode fixed \
@@ -106,8 +106,7 @@ if [[ ":$AYN_LIST:" =~ ":$SYS_ID:"  ]]; then
       --default-touch-mode 4 \
       --hide-cursor-delay 3000 \
       --fade-out-duration 200 \
-      --force-panel-type external \
-      --force-external-orientation left "
+      --force-orientation left "
   fi
   # Set refresh rate range and enable refresh rate switching
   export STEAM_DISPLAY_REFRESH_LIMITS=40,60


### PR DESCRIPTION
This change combined with https://github.com/ChimeraOS/gamescope/pull/9 allows to use native panel refresh rates of 40, 50 and 60 on loki devices.

Tested on the loki zero.