### PR TITLE
Add config param GAMESCOPECMD_BASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ BEFORE_GAMESCOPE_SESSION_PLUS="/bin/turn_on_tv.sh"
 
 #If desired, define an additional command that will be executed after the session ends
 AFTER_GAMESCOPE_SESSION_PLUS="/bin/turn_off_tv.sh"
+
+#Run the task just before starting the client
+BEFORE_GAMESCOPE_CLIENT="/bin/bluetooth-audio-connect.sh"
 ```
 
 # Creating a custom session

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The session sources environment from `~/.config/environment.d/*.conf` files.
 The easiest way to configure the session is to create `~/.config/environment.d/gamescope-session-plus.conf`
 and set variables there:
 
-```
+```sh
 # Size of the screen. If not set gamescope will detect native resolution from drm.
 SCREEN_HEIGHT=2160
 SCREEN_WIDTH=3840
@@ -37,6 +37,15 @@ GAMESCOPECMD="gamescope -e -f"
 # Overwrites only the basic call to composer (useful if composer is on a different path).
 # In this case, the remaining arguments are also set automatically.
 GAMESCOPECMD_BASE="/usr/bin/gamescope"
+
+#Define this if you want composer to run with this option
+ENABLE_GAMESCOPE_WSI=1
+
+#If desired, define an additional command that must be executed before starting the gamescope
+BEFORE_GAMESCOPE_SESSION_PLUS="/bin/turn_on_tv.sh"
+
+#If desired, define an additional command that will be executed after the session ends
+AFTER_GAMESCOPE_SESSION_PLUS="/bin/turn_off_tv.sh"
 ```
 
 # Creating a custom session

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ CLIENTCMD="steam -steamos -pipewire-dmabuf -gamepadui"
 # Override the entire Gamescope command line
 # This will not use screen and render sizes above
 GAMESCOPECMD="gamescope -e -f"
+
+# Overwrites only the basic call to composer (useful if composer is on a different path).
+# In this case, the remaining arguments are also set automatically.
+GAMESCOPECMD_BASE="/usr/bin/gamescope"
 ```
 
 # Creating a custom session

--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -248,6 +248,11 @@ if [ -n "$STEAMCMD" ] ; then
 	CLIENTCMD=$STEAMCMD
 fi
 
+if [[ -n ${BEFORE_GAMESCOPE_CLIENT+x} ]]; then
+  $BEFORE_GAMESCOPE_CLIENT
+fi
+
+bluetoothctl connect 4C:79:6E:F6:43:E7
 # Start client application
 $CLIENTCMD > "${HOME}/.${CLIENT}-stdout.log" 2>&1
 

--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -134,13 +134,17 @@ fi
 : "${OUTPUT_CONNECTOR:=*,eDP-1}"
 
 if [ -z "$GAMESCOPECMD" ] ; then
+    if [ -z "$GAMESCOPECMD_BASE" ] ; then
+        GAMESCOPECMD_BASE="/usr/bin/gamescope"
+    fi
+
     RESOLUTION=""
     if [ -n "$SCREEN_WIDTH" ] && [ -n "$SCREEN_HEIGHT" ] ; then
         RESOLUTION="-W $SCREEN_WIDTH -H $SCREEN_HEIGHT"
     fi
     
     if [ -z $VULKAN_ADAPTER ]; then
-        GAMESCOPECMD="/usr/bin/gamescope \
+        GAMESCOPECMD="${GAMESCOPECMD_BASE} \
         $CURSOR \
         -e \
         $RESOLUTION \
@@ -151,7 +155,7 @@ if [ -z "$GAMESCOPECMD" ] ; then
         --fade-out-duration 200 \
         -R $socket -T $stats"
      else
-        GAMESCOPECMD="/usr/bin/gamescope \
+        GAMESCOPECMD="${GAMESCOPECMD_BASE} \
         $CURSOR \
         -e \
         $RESOLUTION \

--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -96,6 +96,10 @@ do
 done
 set +a
 
+if [[ -n ${BEFORE_GAMESCOPE_SESSION_PLUS+x} ]]; then
+  $BEFORE_GAMESCOPE_SESSION_PLUS
+fi
+
 # Setup socket for gamescope
 # Create run directory file for startup and stats sockets
 tmpdir="$([[ -n ${XDG_RUNTIME_DIR+x} ]] && mktemp -p "$XDG_RUNTIME_DIR" -d -t gamescope.XXXXXXX)"
@@ -271,6 +275,9 @@ if [[ -e "$SHUTDOWN_SENTINEL" ]]; then
 	rm -f "$SHUTDOWN_SENTINEL"
 	# rearm short session tracker
 	rm "$short_session_tracker_file"
+	if [[ -n ${AFTER_GAMESCOPE_SESSION_PLUS+x} ]]; then
+    ${AFTER_GAMESCOPE_SESSION_PLUS}
+  fi
 	poweroff
 fi
 
@@ -297,3 +304,6 @@ for job in $(jobs -p); do
 	kill -9 "$job"
 done
 
+if [[ -n ${AFTER_GAMESCOPE_SESSION_PLUS+x} ]]; then
+  ${AFTER_GAMESCOPE_SESSION_PLUS}
+fi


### PR DESCRIPTION
This setting helps set the base call for the gamescope without overwriting the main algorithm for setting the remaining arguments, which can be useful in some scenarios.