### PR TITLE
Win mini support

### DIFF
--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -3,7 +3,6 @@
 
 SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
 CPU_VENDOR="$(lscpu | grep "Vendor ID" | cut -d : -f 2 | xargs)"
-SCREEN_ID="$(lshw -c video | grep produc | awk '{print $2}')"
 # OXP Devices
 OXP_LIST="ONE XPLAYER:ONEXPLAYER 1 T08:ONEXPLAYER 1S A08:ONEXPLAYER 1S T08:ONEXPLAYER mini A07:ONEXPLAYER mini GA72:ONEXPLAYER mini GT72:ONEXPLAYER Mini Pro:ONEXPLAYER GUNDAM GA72:ONEXPLAYER 2 ARP23:ONEXPLAYER 2 PRO ARP23P:ONEXPLAYER 2 PRO ARP23P EVA-01"
 AOK_LIST="AOKZOE A1 AR07:AOKZOE A1 Pro"
@@ -163,12 +162,15 @@ if [[ ":G1618-04:" =~ ":$SYS_ID:"  ]]; then
    export STEAM_DISPLAY_REFRESH_LIMITS=40,60
 fi
 
-# GPD Win mini 8840U
+# GPD Win mini 2023 and 2024
 if [[ ":G1617-01:" =~ ":$SYS_ID:"  ]]; then
+  SCREEN_ID="$(lshw -c video | grep produc | awk '{print $2}')"
   ROTATION=""
+  # This is the screen of the win mini 2023
   if [[ "Phoenix1" =~ "$SCREEN_ID" ]]; then
      ROTATION=" --force-orientation right "
   fi
+  ## Win mini 2024 uses 'Phoenix3' and doesnt require any aditional settings for rotation
   # Dependent on a special --force-panel-type option in gamescope-plus
   if ( gamescope --help 2>&1 | grep -e "--force-panel-type" > /dev/null ) ; then
     export GAMESCOPECMD="/usr/bin/gamescope \

--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -3,7 +3,7 @@
 
 SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
 CPU_VENDOR="$(lscpu | grep "Vendor ID" | cut -d : -f 2 | xargs)"
-
+SCREEN_ID="$(lshw -c video | grep produc | awk '{print $2}')"
 # OXP Devices
 OXP_LIST="ONE XPLAYER:ONEXPLAYER 1 T08:ONEXPLAYER 1S A08:ONEXPLAYER 1S T08:ONEXPLAYER mini A07:ONEXPLAYER mini GA72:ONEXPLAYER mini GT72:ONEXPLAYER Mini Pro:ONEXPLAYER GUNDAM GA72:ONEXPLAYER 2 ARP23:ONEXPLAYER 2 PRO ARP23P:ONEXPLAYER 2 PRO ARP23P EVA-01"
 AOK_LIST="AOKZOE A1 AR07:AOKZOE A1 Pro"
@@ -161,6 +161,37 @@ if [[ ":G1618-04:" =~ ":$SYS_ID:"  ]]; then
       --fade-out-duration 200 "
    fi
    export STEAM_DISPLAY_REFRESH_LIMITS=40,60
+fi
+
+# GPD Win mini 8840U
+if [[ ":G1617-01:" =~ ":$SYS_ID:"  ]]; then
+  ROTATION=""
+  if [[ "Phoenix1" =~ "$SCREEN_ID" ]]; then
+     ROTATION=" --force-orientation right "
+  fi
+  # Dependent on a special --force-panel-type option in gamescope-plus
+  if ( gamescope --help 2>&1 | grep -e "--force-panel-type" > /dev/null ) ; then
+    export GAMESCOPECMD="/usr/bin/gamescope \
+      -e \
+      --xwayland-count 2 \
+      -O *,eDP-1 \
+      --default-touch-mode 4 \
+      --hide-cursor-delay 3000 \
+      --fade-out-duration 200 \
+      $ROTATION "
+  # fallback for users of gamescope-git.
+  elif ( gamescope --help 2>&1 | grep -e "--force-orientation" > /dev/null ) ; then
+    export GAMESCOPECMD="/usr/bin/gamescope \
+      -e \
+      --xwayland-count 2 \
+      -O *,eDP-1 \
+      --default-touch-mode 4 \
+      --hide-cursor-delay 3000 \
+      --fade-out-duration 200 \
+      $ROTATION "
+  fi
+  # Set refresh rate range and enable refresh rate switching
+#  export STEAM_DISPLAY_REFRESH_LIMITS=40,120
 fi
 
 # Steam Deck

--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -65,8 +65,8 @@ if [[ ":$OXP_120_LIST:" =~ ":$SYS_ID:"  ]]; then
   export STEAM_DISPLAY_REFRESH_LIMITS=40,120
 fi
 
-# AYANEO AIR, SLIDE, and FLIP Devices
-AIR_LIST="AIR:AIR Pro:AIR Plus:SLIDE:FLIP KB:FLIP DS:"
+# AYANEO AIR Devices
+AIR_LIST="AIR:AIR Pro:AIR Plus:SLIDE"
 if [[ ":$AIR_LIST:" =~ ":$SYS_ID:"  ]]; then
   # Dependent on a special --force-external-orientation option in gamescope-plus
   if ( gamescope --help 2>&1 | grep -e "--force-external-orientation" > /dev/null ) ; then
@@ -113,7 +113,7 @@ if [[ ":$AYN_LIST:" =~ ":$SYS_ID:"  ]]; then
 fi
 
 # GDP Win devices
-GDP_LIST="G1619-01:G1621-02:MicroPC:WIN2"
+GDP_LIST="G1619-01:G1621-02:MicroPC"
 if [[ ":$GDP_LIST:" =~ ":$SYS_ID:"  ]]; then
   # Dependent on a special --force-orientation option in gamescope
   if ( gamescope --help 2>&1 | grep -e "--force-orientation" > /dev/null ) ; then
@@ -143,7 +143,7 @@ if [[ ":G1618-03:" =~ ":$SYS_ID:"  ]]; then
       --default-touch-mode 4 \
       --hide-cursor-delay 3000 \
       --fade-out-duration 200 \
-      --force-orientation right "
+      --force-orientation normal "
   fi
 fi
 
@@ -162,39 +162,22 @@ if [[ ":G1618-04:" =~ ":$SYS_ID:"  ]]; then
    export STEAM_DISPLAY_REFRESH_LIMITS=40,60
 fi
 
-# GPD Win mini 2023 and 2024
+# GPD Win mini
 if [[ ":G1617-01:" =~ ":$SYS_ID:"  ]]; then
-  SCREEN_ID="$(lshw -c video | grep produc | awk '{print $2}')"
   ROTATION=""
-  # This is the screen of the win mini 2023
-  if [[ "Phoenix1" =~ "$SCREEN_ID" ]]; then
+  if ( xrandr --prop 2>$1 | grep -e "1080x1920 " > /dev/null ) ; then
      ROTATION=" --force-orientation right "
   fi
-  ## Win mini 2024 uses 'Phoenix3' and doesnt require any aditional settings for rotation
-  # Dependent on a special --force-panel-type option in gamescope-plus
-  if ( gamescope --help 2>&1 | grep -e "--force-panel-type" > /dev/null ) ; then
-    export GAMESCOPECMD="/usr/bin/gamescope \
-      -e \
-      --xwayland-count 2 \
-      -O *,eDP-1 \
-      --default-touch-mode 4 \
-      --hide-cursor-delay 3000 \
-      --fade-out-duration 200 \
-      $ROTATION "
-  # fallback for users of gamescope-git.
-  elif ( gamescope --help 2>&1 | grep -e "--force-orientation" > /dev/null ) ; then
-    export GAMESCOPECMD="/usr/bin/gamescope \
-      -e \
-      --xwayland-count 2 \
-      -O *,eDP-1 \
-      --default-touch-mode 4 \
-      --hide-cursor-delay 3000 \
-      --fade-out-duration 200 \
-      $ROTATION "
-  fi
-  # Set refresh rate range and enable refresh rate switching
-#  export STEAM_DISPLAY_REFRESH_LIMITS=40,120
+  export GAMESCOPECMD="/usr/bin/gamescope \
+     -e \
+     --xwayland-count 2 \
+     -O *,eDP-1 \
+     --default-touch-mode 4 \
+     --hide-cursor-delay 3000 \
+     --fade-out-duration 200 \
+     $ROTATION "
 fi
+
 
 # Steam Deck
 if [[ ":Jupiter:" =~ ":$SYS_ID:"  ]]; then

--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -3,6 +3,7 @@
 
 SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
 CPU_VENDOR="$(lscpu | grep "Vendor ID" | cut -d : -f 2 | xargs)"
+
 # OXP Devices
 OXP_LIST="ONE XPLAYER:ONEXPLAYER 1 T08:ONEXPLAYER 1S A08:ONEXPLAYER 1S T08:ONEXPLAYER mini A07:ONEXPLAYER mini GA72:ONEXPLAYER mini GT72:ONEXPLAYER Mini Pro:ONEXPLAYER GUNDAM GA72:ONEXPLAYER 2 ARP23:ONEXPLAYER 2 PRO ARP23P:ONEXPLAYER 2 PRO ARP23P EVA-01"
 AOK_LIST="AOKZOE A1 AR07:AOKZOE A1 Pro"
@@ -65,8 +66,8 @@ if [[ ":$OXP_120_LIST:" =~ ":$SYS_ID:"  ]]; then
   export STEAM_DISPLAY_REFRESH_LIMITS=40,120
 fi
 
-# AYANEO AIR Devices
-AIR_LIST="AIR:AIR Pro:AIR Plus:SLIDE"
+# AYANEO AIR, SLIDE, and FLIP Devices
+AIR_LIST="AIR:AIR Pro:AIR Plus:SLIDE:FLIP KB:FLIP DS:"
 if [[ ":$AIR_LIST:" =~ ":$SYS_ID:"  ]]; then
   # Dependent on a special --force-external-orientation option in gamescope-plus
   if ( gamescope --help 2>&1 | grep -e "--force-external-orientation" > /dev/null ) ; then
@@ -113,7 +114,7 @@ if [[ ":$AYN_LIST:" =~ ":$SYS_ID:"  ]]; then
 fi
 
 # GDP Win devices
-GDP_LIST="G1619-01:G1621-02:MicroPC"
+GDP_LIST="G1619-01:G1621-02:MicroPC:WIN2"
 if [[ ":$GDP_LIST:" =~ ":$SYS_ID:"  ]]; then
   # Dependent on a special --force-orientation option in gamescope
   if ( gamescope --help 2>&1 | grep -e "--force-orientation" > /dev/null ) ; then
@@ -143,7 +144,7 @@ if [[ ":G1618-03:" =~ ":$SYS_ID:"  ]]; then
       --default-touch-mode 4 \
       --hide-cursor-delay 3000 \
       --fade-out-duration 200 \
-      --force-orientation normal "
+      --force-orientation right "
   fi
 fi
 
@@ -177,7 +178,6 @@ if [[ ":G1617-01:" =~ ":$SYS_ID:"  ]]; then
      --fade-out-duration 200 \
      $ROTATION "
 fi
-
 
 # Steam Deck
 if [[ ":Jupiter:" =~ ":$SYS_ID:"  ]]; then
@@ -254,4 +254,3 @@ if [[ ":83E1:" =~ ":$SYS_ID:"  ]]; then
       --force-orientation left "
   fi
 fi
-


### PR DESCRIPTION
Entry for all win mini devices.

Uses 'lshw -c video'  to differentiate between win mini 2023 (7840/7640) and win mini 2024 (8840) devices.

Still requires some changes to support different refresh rates and need more details into whats needed for VRR to work 
