### PR TITLE
Force xwayland mode for Qt applications

### DIFF
--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -21,6 +21,9 @@ post_gamescope_start () {
 export INTEL_DEBUG=norbc
 export mesa_glthread=true
 
+# Force Qt applications to run under xwayland
+export QT_QPA_PLATFORM=xcb
+
 # Some environment variables by default (taken from Deck session)
 export SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS=0
 


### PR DESCRIPTION
Globally configuring Qt (like via `/etc/environment`) to run natively in wayland mode `QT_QPA_PLATFORM=wayland` (or even with `QT_QPA_PLATFORM=wayland:xcb` to support x11 fallback) will prevent Qt applications to start under `gamescope`, this change forces Qt apps to run in X11 mode for gamescope to grab them.

The use of QT_QPA_PLATFORM is [documented in the arch wiki wayland page.](https://wiki.archlinux.org/title/Wayland#Qt)

2024.06.18 edit: fixing typos, adding arch wiki link