### PR TITLE
Update quirks to match new gamescope-plus rebase

### DIFF
--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -9,8 +9,8 @@ OXP_LIST="ONE XPLAYER:ONEXPLAYER 1 T08:ONEXPLAYER 1S A08:ONEXPLAYER 1S T08:ONEXP
 AOK_LIST="AOKZOE A1 AR07:AOKZOE A1 Pro"
 if [[ ":$OXP_LIST:" =~ ":$SYS_ID:"  ]] || [[  ":$AOK_LIST:" =~ ":$SYS_ID:"   ]]; then
   # Intel support is extremely experimental, this is the bare minimum to get the system to boot.
-  # Dependent on a special --force-external-orientation option in gamescope
-  if ( gamescope --help 2>&1 | grep -e "--force-external-orientation" > /dev/null ) &&  [[ "$CPU_VENDOR" =~ "GenuineIntel" ]]; then
+  # Dependent on a special --force-panel-type option in gamescope
+  if ( gamescope --help 2>&1 | grep -e "--force-panel-type" > /dev/null ) &&  [[ "$CPU_VENDOR" =~ "GenuineIntel" ]]; then
     export GAMESCOPECMD="/usr/bin/gamescope \
       -e \
       --generate-drm-mode fixed \
@@ -20,7 +20,7 @@ if [[ ":$OXP_LIST:" =~ ":$SYS_ID:"  ]] || [[  ":$AOK_LIST:" =~ ":$SYS_ID:"   ]];
       --hide-cursor-delay 3000 \
       --fade-out-duration 200 \
       --force-panel-type external \
-      --force-external-orientation left "
+      --force-orientation left "
   # Fallback method. Dependent on a special --force-orientation option in gamescope
   elif ( gamescope --help 2>&1 | grep -e "--force-orientation" > /dev/null ) ; then
     export GAMESCOPECMD="/usr/bin/gamescope \
@@ -40,8 +40,8 @@ fi
 # OXP 120hz Devices
 OXP_120_LIST="ONEXPLAYER F1"
 if [[ ":$OXP_120_LIST:" =~ ":$SYS_ID:"  ]]; then
-  # Dependent on a special --force-external-orientation option in gamescope-plus
-  if ( gamescope --help 2>&1 | grep -e "--force-external-orientation" > /dev/null ) ; then
+  # Dependent on a special --force-panel-type option in gamescope-plus
+  if ( gamescope --help 2>&1 | grep -e "--force-panel-type" > /dev/null ) ; then
     export GAMESCOPECMD="/usr/bin/gamescope \
       -e \
       --xwayland-count 2 \
@@ -50,7 +50,7 @@ if [[ ":$OXP_120_LIST:" =~ ":$SYS_ID:"  ]]; then
       --hide-cursor-delay 3000 \
       --fade-out-duration 200 \
       --force-panel-type external \
-      --force-external-orientation left "
+      --force-orientation left "
   # Fallback method. Dependent on a special --force-orientation option in gamescope
   elif ( gamescope --help 2>&1 | grep -e "--force-orientation" > /dev/null ) ; then
     export GAMESCOPECMD="/usr/bin/gamescope \
@@ -69,8 +69,8 @@ fi
 # AYANEO AIR, SLIDE, and FLIP Devices
 AIR_LIST="AIR:AIR Pro:AIR Plus:SLIDE:FLIP KB:FLIP DS:"
 if [[ ":$AIR_LIST:" =~ ":$SYS_ID:"  ]]; then
-  # Dependent on a special --force-external-orientation option in gamescope-plus
-  if ( gamescope --help 2>&1 | grep -e "--force-external-orientation" > /dev/null ) ; then
+  # Dependent on a special --force-panel-type option in gamescope-plus
+  if ( gamescope --help 2>&1 | grep -e "--force-panel-type" > /dev/null ) ; then
     export GAMESCOPECMD="/usr/bin/gamescope \
       -e \
       --xwayland-count 2 \
@@ -79,7 +79,7 @@ if [[ ":$AIR_LIST:" =~ ":$SYS_ID:"  ]]; then
       --hide-cursor-delay 3000 \
       --fade-out-duration 200 \
       --force-panel-type external \
-      --force-external-orientation left "
+      --force-orientation left "
   # Fallback method. Dependent on a special --force-orientation option in gamescope
   elif ( gamescope --help 2>&1 | grep -e "--force-orientation" > /dev/null ) ; then
     export GAMESCOPECMD="/usr/bin/gamescope \
@@ -96,8 +96,8 @@ fi
 # AYN Loki Devices
 AYN_LIST="Loki Max:Loki Zero:Loki MiniPro"
 if [[ ":$AYN_LIST:" =~ ":$SYS_ID:"  ]]; then
-  # Dependent on a special --force-external-orientation option in gamescope
-  if ( gamescope --help 2>&1 | grep -e "--force-external-orientation" > /dev/null ) ; then
+  # Dependent on a special --force-panel-type option in gamescope
+  if ( gamescope --help 2>&1 | grep -e "--force-panel-type" > /dev/null ) ; then
     export GAMESCOPECMD="/usr/bin/gamescope \
       -e \
       --generate-drm-mode fixed \
@@ -107,7 +107,7 @@ if [[ ":$AYN_LIST:" =~ ":$SYS_ID:"  ]]; then
       --hide-cursor-delay 3000 \
       --fade-out-duration 200 \
       --force-panel-type external \
-      --force-external-orientation left "
+      --force-orientation left "
   fi
   # Set refresh rate range and enable refresh rate switching
   export STEAM_DISPLAY_REFRESH_LIMITS=40,60


### PR DESCRIPTION
`Gamescope-plus` will no longer need `--force-external-orientation` since `--force-orientation` will now be able to control both real internal and fake external displays.