### PR TITLE
prefer the top screen for flip-ds

### DIFF
--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -37,7 +37,7 @@ fi
 if [[ ":FLIP DS:" =~ ":$SYS_ID:" ]]; then
   PANEL_TYPE=external
   ORIENTATION=left
-  OUTPUT_CONNECTOR='*,eDP-2' # prefer the top screen
+  OUTPUT_CONNECTOR='*,eDP-1,eDP-2' # prefer the top screen
 fi
 
 # AYN Loki Devices


### PR DESCRIPTION
The screen at the top is eDP-1, and the bottom is eDP-2. Make sure that eDP-2 is placed at the end.