### PR TITLE
Add REFRESH_RATE option to lock game mode to specified refresh rate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ and set variables there:
 SCREEN_HEIGHT=2160
 SCREEN_WIDTH=3840
 
+# Lock Game Mode to the specified refresh rate in hz. Monitor must support refresh rate.
+REFRESH_RATE=60
+
 # Override entire client command line
 CLIENTCMD="steam -steamos -pipewire-dmabuf -gamepadui"
 

--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -162,6 +162,11 @@ if [ -z "$GAMESCOPECMD" ]; then
 		DRM_MODE_OPTION="--generate-drm-mode $DRM_MODE"
 	fi
 
+	REFRESH_RATE_OPTION=""
+        if [ -n "$REFRESH_RATE" ]; then
+                REFRESH_RATE_OPTION="-r $REFRESH_RATE"
+        fi
+
 	ORIENTATION_OPTION=""
 	if [ -n "$ORIENTATION" ] ; then
 		ORIENTATION_OPTION="--force-orientation $ORIENTATION"
@@ -186,6 +191,7 @@ if [ -z "$GAMESCOPECMD" ]; then
 		$CURSOR \
 		$RESOLUTION \
 		$INTERNAL_RESOLUTION \
+		$REFRESH_RATE_OPTION \
 		$ORIENTATION_OPTION \
 		$DRM_MODE_OPTION \
 		$BYPASS_STEAM_RESOLUTION \


### PR DESCRIPTION
I wanted a way to reduce the Legion Go's refresh rate to 60 Hz from the default of 144 Hz. Running at 144 Hz consumes additional power and is overkill for most of my use cases. I tested this locally on the device and seems to work well (setting a value of 60 removes 144 from being an option entirely from the right side menu).