### PR TITLE
Use new custom-refresh-rate option in gamescope

### DIFF
--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -44,8 +44,8 @@ fi
 AYN_LIST="Loki Max:Loki Zero:Loki MiniPro"
 if [[ ":$AYN_LIST:" =~ ":$SYS_ID:"  ]]; then
   DRM_MODE=fixed
-  PANEL_TYPE=external
   ORIENTATION=left
+  CUSTOM_REFRESH_RATES=40,50,60
 
   # Set refresh rate range and enable refresh rate switching
   export STEAM_DISPLAY_REFRESH_LIMITS=40,60
@@ -107,6 +107,10 @@ fi
 if [[ ":83E1:" =~ ":$SYS_ID:"  ]]; then
   ORIENTATION=left
   ADAPTIVE_SYNC=1
+  CUSTOM_REFRESH_RATES=60,144
+
+  # Set refresh rate range and enable refresh rate switching
+  export STEAM_DISPLAY_REFRESH_LIMITS=60,144
 fi
 
 # Aya Neo 2 & 2S

--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -182,6 +182,11 @@ if [ -z "$GAMESCOPECMD" ]; then
 		BYPASS_STEAM_RESOLUTION="--bypass-steam-resolution"
 	fi
 
+	CUSTOM_REFRESH_RATES_OPTION=""
+	if [ -n "$CUSTOM_REFRESH_RATES" ] && gamescope_has_option "--custom-refresh-rates"; then
+		CUSTOM_REFRESH_RATES_OPTION="--custom-refresh-rates $CUSTOM_REFRESH_RATES"
+	fi
+
 	GAMESCOPECMD="/usr/bin/gamescope \
 		$CURSOR \
 		$RESOLUTION \
@@ -189,7 +194,9 @@ if [ -z "$GAMESCOPECMD" ]; then
 		$ORIENTATION_OPTION \
 		$DRM_MODE_OPTION \
 		$BYPASS_STEAM_RESOLUTION \
+		$ADAPTIVE_SYNC_OPTION \
 		$PANEL_TYPE_OPTION \
+		$CUSTOM_REFRESH_RATES_OPTION \
 		--prefer-output $OUTPUT_CONNECTOR \
 		--xwayland-count $XWAYLAND_COUNT \
 		--default-touch-mode $TOUCH_MODE \


### PR DESCRIPTION
Pre-fill hardware that benefits from it in device-quirks (Set Loki to internal display, set Steam framerate control arg for Legion)
Fix adaptive sync never being applied

Alternative to #96 that uses the correct framerate range by default and can be customized by the end-user.
Supersedes #83