### PR TITLE
feat(GPD): Add custom refresh rates for GPD Win 4 and Win Max 2

### DIFF
--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -70,6 +70,13 @@ fi
 
 #GPD Win 4 supports 40-60hz refresh rate changing
 if [[ ":G1618-04:" =~ ":$SYS_ID:"  ]]; then
+  CUSTOM_REFRESH_RATES=40,60
+  export STEAM_DISPLAY_REFRESH_LIMITS=40,60
+fi
+
+# GPD Win Max 2 supports 40,60hz
+if [[ ":G1619-04:" =~ ":$SYS_ID:"  ]]; then
+  CUSTOM_REFRESH_RATES=40,60
   export STEAM_DISPLAY_REFRESH_LIMITS=40,60
 fi
 


### PR DESCRIPTION
This enables the unified refresh rate limiter for the GPD Win 4 and WM2

note, i'm still investigating other supported refresh rates for the Win 4, so far it looks like 40,44,45,60 all work on the GPD Win 4

but 40,60 should be safe values, and I don't know how much value there'd be to add support for values like 44, 45, etc