### PR TITLE
Split Steam Deck into LCD, OLED, and Common.

### DIFF
--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -88,16 +88,54 @@ if [[ ":G1617-01:" =~ ":$SYS_ID:"  ]]; then
   fi
 fi
 
-# Steam Deck
-if [[ ":Jupiter:" =~ ":$SYS_ID:"  ]]; then
+# Steam Deck (Common)
+if [[ ":Jupiter:Galileo:" =~ ":$SYS_ID:" ]]; then
   DRM_MODE=fixed
-  export STEAM_DISPLAY_REFRESH_LIMITS=40,60
+  DONT_BYPASS_RESOLUTION=1
+
+  # Enables the adaptive brightness toggle
+  export STEAM_ENABLE_DYNAMIC_BACKLIGHT=1
+  # Allows the fan controller service to be toggled from gamemode
+  export STEAM_ENABLE_FAN_CONTROL=1
+  # Sets CPU topology for Steam Deck hardware
+  export WINE_CPU_TOPOLOGY=8:0,1,2,3,4,5,6,7
+
+  # Prevent default power button behavior
+  systemd-inhibit --what=handle-suspend-key:handle-power-key:handle-hibernate-key --who=gamescope-session --why="gamescope-session handles power button events" sleep infinity &
+  inhibitor_pid="$!"
+
+  # Start SteamOS's power button handler daemon, this passes power button events to Steam.
+  if command -v /usr/bin/powerbuttond > /dev/null; then
+    (while true; do
+      /usr/bin/powerbuttond
+    done) &
+  elif [ -f /usr/lib/hwsupport/power-button-handler.py ]; then
+    (while true; do
+      /usr/bin/python3 /usr/lib/hwsupport/power-button-handler.py
+    done) &
+  fi
 fi
 
-# OLED Steam Deck
-if [[ ":Galileo:" =~ ":$SYS_ID:"  ]]; then
-  DRM_MODE=fixed
+# Steam Deck (LCD)
+if [[ ":Jupiter:" =~ ":$SYS_ID:" ]]; then
+  export STEAM_DISPLAY_REFRESH_LIMITS=40,60
+
+  if [ -f "/usr/share/plymouth/themes/steamos/steamos-jupiter.png" ]; then
+    export STEAM_UPDATEUI_PNG_BACKGROUND=/usr/share/plymouth/themes/steamos/steamos-jupiter.png
+  fi
+fi
+
+# Steam Deck (OLED)
+if [[ ":Galileo:" =~ ":$SYS_ID:" ]]; then
   export STEAM_DISPLAY_REFRESH_LIMITS=45,90
+
+  export STEAM_GAMESCOPE_FORCE_HDR_DEFAULT=1
+  export STEAM_GAMESCOPE_FORCE_OUTPUT_TO_HDR10PQ_DEFAULT=1
+  export STEAM_ENABLE_STATUS_LED_BRIGHTNESS=1
+
+  if [ -f "/usr/share/plymouth/themes/steamos/steamos-galileo.png" ]; then
+    export STEAM_UPDATEUI_PNG_BACKGROUND=/usr/share/plymouth/themes/steamos/steamos-galileo.png
+  fi
 fi
 
 # ROG Ally

--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -102,7 +102,6 @@ if [[ ":Jupiter:Galileo:" =~ ":$SYS_ID:" ]]; then
 
   # Prevent default power button behavior
   systemd-inhibit --what=handle-suspend-key:handle-power-key:handle-hibernate-key --who=gamescope-session --why="gamescope-session handles power button events" sleep infinity &
-  inhibitor_pid="$!"
 
   # Start SteamOS's power button handler daemon, this passes power button events to Steam.
   if command -v /usr/bin/powerbuttond > /dev/null; then

--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
+
 declare -r CLIENT=$1
 declare -r CLIENT_CONFIG_DIR_USR=/usr/share/gamescope-session-plus/sessions.d
 declare -r CLIENT_CONFIG_DIR_ETC=/etc/gamescope-session-plus/sessions.d
@@ -187,7 +189,7 @@ if [ -z "$GAMESCOPECMD" ]; then
 	fi
 
 	BYPASS_STEAM_RESOLUTION=""
-	if gamescope_has_option "--bypass-steam-resolution"; then
+	if [ ! -n "$DONT_BYPASS_RESOLUTION" ] && gamescope_has_option "--bypass-steam-resolution"; then
 		BYPASS_STEAM_RESOLUTION="--bypass-steam-resolution"
 	fi
 
@@ -281,6 +283,14 @@ if command -v mangoapp >/dev/null; then
 	(while true; do
 		mangoapp >"${HOME}"/.mangoapp-stdout.log 2>&1
 	done) &
+fi
+
+# Handle Galileo Mura Correction
+# This is applied here and not in device-quirks because it must be called after gamescope has started.
+if [[ ":Galileo:" =~ ":$SYS_ID:"  ]]; then
+  if command -v galileo-mura-setup > /dev/null; then
+    galileo-mura-setup &
+  fi
 fi
 
 # For compatibility with older user configuration overrides


### PR DESCRIPTION
Add variables used by Valve.
Add support for power button handlers.
Skip resolution bypass behavior on Deck hardware.
Add mura correction
Add CPU topography change in upstream Valve gamescope session