### PR TITLE
Add support for /usr/bin/gamescope-legacy

### DIFF
--- a/usr/libexec/gamescope-sdl-workaround
+++ b/usr/libexec/gamescope-sdl-workaround
@@ -4,7 +4,7 @@
 # Regexes for GPUs requiring the SDL backend workaround
 # Can be used in regexes as $POLARIS_RE|$VEGA_RE etc for readability
 # Needed output for a regex can gathered from "switcherooctl list"
-POLARIS_RE="Ellesmere|Lexa PRO|RX 470/480/570/570X/580/580X/590|540/540X/550/550X|RX 540X/550/550X"
+POLARIS_RE="Ellesmere|Lexa PRO|Polaris \d{2} XL|RX 470/480/570/570X/580/580X/590|540/540X/550/550X|RX 540X/550/550X"
 
 # Used to combine all regex into 1 var ex: FINALE_RE="$POLARIS_RE|$VEGA_RE"
 FINAL_RE="$POLARIS_RE"

--- a/usr/libexec/gamescope-sdl-workaround
+++ b/usr/libexec/gamescope-sdl-workaround
@@ -1,0 +1,57 @@
+#!/usr/bin/bash
+# Script returns true if a card requiring sdl workaround is detected
+
+# Regexes for GPUs requiring the SDL backend workaround
+# Can be used in regexes as $POLARIS_RE|$VEGA_RE etc for readability
+# Needed output for a regex can gathered from "switcherooctl list"
+POLARIS_RE="Ellesmere|Lexa PRO|RX 470/480/570/570X/580/580X/590|540/540X/550/550X|RX 540X/550/550X"
+
+# Used to combine all regex into 1 var ex: FINALE_RE="$POLARIS_RE|$VEGA_RE"
+FINAL_RE="$POLARIS_RE"
+
+# Get the users homedirs so we can check for export-gpu configs
+HOMES=$(grep "/home" /etc/passwd | awk -F ":" '{ print $6 }')
+
+# Find all GPUs using lspci
+VGA_CONTROLLERS=$(lspci -nn | grep -P "(VGA compatible|3D) controller")
+
+# Check inside users home if gamescope is configured to use a specific GPU
+# This at least does not break gamescope on systems where users have re-enabled the sddm login screen
+while IFS= read -r USERDIR
+do
+    # If a vulkan device config is present
+    if [ -f "$USERDIR/.config/environment.d/00-vulkan-device.conf" ]; then
+        # Check if a vulkan device is configured
+        VULKAN_GPU=$(grep -P "^VULKAN_ADAPTER=" "$USERDIR/.config/environment.d/00-vulkan-device.conf" | sed 's/VULKAN_ADAPTER=//')
+
+        # Write info to journal
+        echo "INFO: VULKAN_ADAPTER is set to $VULKAN_GPU by env config." | systemd-cat -t gamescope-sdl-workaround -p info
+
+        # If a vulkan device is configured
+        if [ -n "$VULKAN_GPU" ]; then
+            # Replace list of VGA controllers with just this device
+            VGA_CONTROLLERS=$(lspci -nn -d "$VULKAN_GPU")
+        fi
+    fi
+done <<< "$HOMES"
+
+# Process the VGA controllers list to see if we match any cards that need the sdl workaround
+while IFS= read -r GPU
+do
+    # If we match with a card that requires sdl workaround
+    if [[ "$GPU" =~ ($FINAL_RE) ]]; then
+        # Write info to journal
+        echo "INFO: $GPU detected" | systemd-cat -t gamescope-sdl-workaround -p info
+        echo "INFO: SDL backend workaround will be applied." | systemd-cat -t gamescope-sdl-workaround -p info
+
+        # This gpu requires sdl workaround, exit 0 (true)
+        exit 0
+    fi
+done <<< "$VGA_CONTROLLERS"
+
+# Write info to journalctl
+echo "INFO: SDL backend workaround not required for this system" | systemd-cat -t gamescope-sdl-workaround -p info
+echo 'INFO: If SDL backend workaround IS required for your card. Provide your "lspci -nn | grep -P '"'"'(VGA compatible|3D) controller'"'"'" to the developers.' | systemd-cat -t gamescope-sdl-workaround -p info
+
+# This GPU does not require sdl workaround, exit 1 (false)
+exit 1

--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -137,8 +137,3 @@ if [[ ":V3:" =~ ":$SYS_ID:"  ]]; then
   # Set refresh rate range and enable refresh rate switching
   export STEAM_DISPLAY_REFRESH_LIMITS=36,165
 fi
-
-# GPUs that require the SDL backend
-if [ -x /usr/libexec/gamescope-sdl-workaround ] && /usr/libexec/gamescope-sdl-workaround; then
-  BACKEND=sdl
-fi

--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -137,3 +137,8 @@ if [[ ":V3:" =~ ":$SYS_ID:"  ]]; then
   # Set refresh rate range and enable refresh rate switching
   export STEAM_DISPLAY_REFRESH_LIMITS=36,165
 fi
+
+# GPUs that require the SDL backend
+if [ -x /usr/libexec/gamescope-sdl-workaround ] && /usr/libexec/gamescope-sdl-workaround; then
+  BACKEND=sdl
+fi

--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -15,8 +15,17 @@ post_gamescope_start() {
 	:
 }
 
+get_gamescope_binary() {
+	# GPUs that require the SDL backend
+	if /usr/libexec/gamescope-sdl-workaround && command -v /usr/bin/gamescope-legacy >/dev/null; then
+		echo "/usr/bin/gamescope-legacy"
+	else
+		echo "/usr/bin/gamescope"
+	fi
+}
+
 gamescope_has_option() {
-	if (gamescope --help 2>&1 | grep -e "$1" > /dev/null); then
+	if ($(get_gamescope_binary) --help 2>&1 | grep -e "$1" > /dev/null); then
 		return 0
 	fi
 
@@ -202,7 +211,7 @@ if [ -z "$GAMESCOPECMD" ]; then
 		BACKEND_OPTION="--backend $BACKEND"
 	fi
 
-	GAMESCOPECMD="/usr/bin/gamescope \
+	GAMESCOPECMD="$(get_gamescope_binary) \
 		$CURSOR \
 		$RESOLUTION \
 		$INTERNAL_RESOLUTION \

--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -196,6 +196,12 @@ if [ -z "$GAMESCOPECMD" ]; then
 		CUSTOM_REFRESH_RATES_OPTION="--custom-refresh-rates $CUSTOM_REFRESH_RATES"
 	fi
 
+	BACKEND_OPTION=""
+	# Check if an older GPU that needs the SDL workaround is in use.
+	if [ -n "$BACKEND" ] && gamescope_has_option "--backend"; then
+		BACKEND_OPTION="--backend $BACKEND"
+	fi
+
 	GAMESCOPECMD="/usr/bin/gamescope \
 		$CURSOR \
 		$RESOLUTION \
@@ -206,6 +212,7 @@ if [ -z "$GAMESCOPECMD" ]; then
 		$ADAPTIVE_SYNC_OPTION \
 		$PANEL_TYPE_OPTION \
 		$CUSTOM_REFRESH_RATES_OPTION \
+		$BACKEND_OPTION \
 		--prefer-output $OUTPUT_CONNECTOR \
 		--xwayland-count $XWAYLAND_COUNT \
 		--default-touch-mode $TOUCH_MODE \

--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -40,7 +40,12 @@ export mesa_glthread=true
 
 # This should be used by default by gamescope. Cannot hurt to force it anyway.
 # Reported better framelimiting with this enabled
-export ENABLE_GAMESCOPE_WSI=1
+if /usr/libexec/gamescope-sdl-workaround; then
+	# Skip on legacy hardware
+	export ENABLE_GAMESCOPE_WSI=0
+else
+	export ENABLE_GAMESCOPE_WSI=1
+fi
 
 # Force Qt applications to run under xwayland
 export QT_QPA_PLATFORM=xcb


### PR DESCRIPTION
Certain GPUs (AMD RX 5xx and below) require an older build of Gamescope to function at this time. This change adds a detection method for them and a switch to a legacy binary at /usr/bin/gamescope-legacy

This also adds the --backend option, but intentionally never sets it as that fix is unfortunately not yet a complete one. Consider it a possible future option.