### PR TITLE
Add support for switcheroo

### DIFF
--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -319,8 +319,8 @@ if [ -n "$STEAMCMD" ]; then
 	CLIENTCMD=$STEAMCMD
 fi
 
-# Start client application
-$CLIENTCMD >"${HOME}/.${CLIENT}-stdout.log" 2>&1
+# Start client application with switcheroo to ensure it's on the correct GPU
+switcherooctl launch $CLIENTCMD >"${HOME}/.${CLIENT}-stdout.log" 2>&1
 
 if [[ "$SECONDS" -lt "$short_session_duration" ]]; then
 	echo "${CLIENT} failed" >>"$short_session_tracker_file"


### PR DESCRIPTION
This is something bazzite has been shipping for a while, so putting it here for comment

Switcheroo is a GPU switching system that is used by both KDE and GNOME to select the correct GPU on multi-GPU systems when requested by an application. The Steam desktop file has the entry that triggers both DEs to run it using switcheroo, so this matches the same behavior in the gamescope session. Gamescope will use the same GPU it does now (or the one selected by the user with export-gpu) and Steam will run on the alt-GPU selected by Switcheroo.

This makes it easy to run gamescope on an iGPU and Steam + Games on a dGPU on a laptop.