### PR TITLE
Remove ADAPTIVE_SYNC=1 from Legion Go

### DIFF
--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -150,7 +150,6 @@ fi
 # Lenovo Legion Go
 if [[ ":83E1:" =~ ":$SYS_ID:"  ]]; then
   ORIENTATION=left
-  ADAPTIVE_SYNC=1
   CUSTOM_REFRESH_RATES=60,144
 
   # Set refresh rate range and enable refresh rate switching


### PR DESCRIPTION
Doesn't cause issues one way or the other. Legion Go does not come with a VRR display so it simply should not be there. May be a hold over from prior to the CUSTOM_REFRESH_RATES option being available.