### PR TITLE
add OneXPlayer X1 intel support

### DIFF
--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -27,6 +27,17 @@ if [[ ":$OXP_120_LIST:" =~ ":$SYS_ID:"  ]]; then
 fi
 
 # OXP X1 Devices
+OXP_X1_LIST="ONEXPLAYER X1 i"
+if [[ ":$OXP_X1_LIST:" =~ ":$SYS_ID:"  ]]; then
+  PANEL_TYPE=internal
+  USE_ROTATION_SHADER=1
+  ORIENTATION=left
+  CUSTOM_REFRESH_RATES=60,120
+
+  # Set refresh rate range and enable refresh rate switching
+  export STEAM_DISPLAY_REFRESH_LIMITS=60,120
+fi
+
 OXP_X1_LIST="ONEXPLAYER X1 A"
 if [[ ":$OXP_X1_LIST:" =~ ":$SYS_ID:"  ]]; then
   PANEL_TYPE=external

--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -219,6 +219,11 @@ if [ -z "$GAMESCOPECMD" ]; then
 		CUSTOM_REFRESH_RATES_OPTION="--custom-refresh-rates $CUSTOM_REFRESH_RATES"
 	fi
 
+	USE_ROTATION_SHADER_OPTION=""
+	if [ -n "$USE_ROTATION_SHADER" ] && gamescope_has_option "--use-rotation-shader"; then
+		USE_ROTATION_SHADER_OPTION="--use-rotation-shader $USE_ROTATION_SHADER"
+	fi
+
 	BACKEND_OPTION=""
 	# Check if an older GPU that needs the SDL workaround is in use.
 	if [ -n "$BACKEND" ] && gamescope_has_option "--backend"; then
@@ -235,6 +240,7 @@ if [ -z "$GAMESCOPECMD" ]; then
 		$ADAPTIVE_SYNC_OPTION \
 		$PANEL_TYPE_OPTION \
 		$CUSTOM_REFRESH_RATES_OPTION \
+		$USE_ROTATION_SHADER_OPTION \
 		$BACKEND_OPTION \
 		--prefer-output $OUTPUT_CONNECTOR \
 		--xwayland-count $XWAYLAND_COUNT \


### PR DESCRIPTION
support for OneXPlayer X1 intel is added in conjunction with a PR in gamescope: https://github.com/ChimeraOS/gamescope/pull/16