### PR TITLE
Add support for XG mobile devices

### DIFF
--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -189,3 +189,27 @@ if [[ ":V3:" =~ ":$SYS_ID:"  ]]; then
   # Set refresh rate range and enable refresh rate switching
   export STEAM_DISPLAY_REFRESH_LIMITS=36,165
 fi
+
+# XG mobile for ASUS laptops that supports the proprietary connector
+xg_mobile_file_path="/sys/devices/virtual/firmware-attributes/asus-armoury/attributes/egpu_enable/current_value"
+if [ -f "$xg_mobile_file_path" ]; then
+  egpu_status=$(<"$xg_mobile_file_path")
+  if [[ "$egpu_status" -ne 0 ]]; then
+    unset STEAM_DISPLAY_REFRESH_LIMITS
+
+    # XG Mobile 2023: NVIDIA 4090
+    if lspci -nn | grep -Fq "10de:2717"; then
+      export VULKAN_ADAPTER="10de:2717"
+    fi
+
+    # XG Mobile 2022: AMD RX 6850xt
+    if lspci -nn | grep -Fq "1002:73df"; then
+      export VULKAN_ADAPTER="1002:73df"
+    fi
+
+    # XG Mobile 2021: NVIDIA 3080
+    if lspci -nn | grep -q "10de:249c"; then
+      export VULKAN_ADAPTER="1002:249c"
+    fi
+  fi
+fi


### PR DESCRIPTION
Certain ASUS laptops and the ROG ally (only first generation) have a proprietary connector for external GPUs: if one is attached and enabled that GPU should be preferred over whatever the default is