### PR TITLE
feat: Add support for ONEXPLAYER G1 AMD HX

### DIFF
--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -59,11 +59,11 @@ if [[ ":$OXP_X1_144_LIST:" =~ ":$SYS_ID:"  ]]; then
   export STEAM_DISPLAY_REFRESH_LIMITS=60,144
 fi
 
-# OXP G1 Intel Devices
-OXP_G1_INTEL_LIST="ONEXPLAYER G1 i"
-if [[ ":$OXP_G1_INTEL_LIST:" =~ ":$SYS_ID:"  ]]; then
+# OXP G1 Devices
+if [[ ":$SYS_ID:" =~ :ONEXPLAYER\ G1\ (A|i): ]]; then
   PANEL_TYPE=internal
-  USE_ROTATION_SHADER=1
+  # AMD version has hardware rotation
+  [[ ":$SYS_ID:" =~ ":ONEXPLAYER G1 i:" ]] && USE_ROTATION_SHADER=1
   ORIENTATION=left
   CUSTOM_REFRESH_RATES=60,144
 


### PR DESCRIPTION
The AMD version has hardware rotation so using rotation shader shouldn't be necessary.