### PR TITLE
[GPD Win 4] Support for custom display firmware flash that disables the landscape screen rotation…

### DIFF
--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -115,6 +115,11 @@ fi
 
 #GPD Win 4 supports 40-60hz refresh rate changing
 if [[ ":G1618-04:" =~ ":$SYS_ID:"  ]]; then
+  ORIENTATION=""
+  # Support for custom display firmware flash that disables the landscape screen rotation (which adds input latency)
+  if ( xrandr --prop 2>$1 | grep -e "1080x1920 " > /dev/null ) ; then
+     ORIENTATION=right
+  fi
   CUSTOM_REFRESH_RATES=40,60
   export STEAM_DISPLAY_REFRESH_LIMITS=40,60
 fi


### PR DESCRIPTION
…which adds input latency. Around 50ms to be precise.

This year, a known issue with the GPD Win 4 was addressed thanks to the community members and GPD themselves helping out - the input latency caused by the IC chip that rotates the native portrait screen to landscape.

Some Reddit posts about this issue:

https://www.reddit.com/r/gpdwin/comments/1j4lakw/dont_buy_a_gpd_win_4_until_gpd_actually_fixes_the/
https://www.reddit.com/r/gpdwin/comments/1448rqi/gpd_please_fix_the_win4_input_lag_issue/

For a few models, GPD provided a flashable software fix, which essentially disables the rotation and returns the screen into it's native 1080x1920 resolution. This creates some problems here in gamescope, especially with orientation. Similar to the Win Mini fix, this just checks if the screen is portrait.

This applies to all GPD models - the community figured out a way to reprogram the chip directly on the models that can't be software flashed (2025 HX 370 variants), same issue will happen there if screen is not re-oriented in software instead.