### PR TITLE
feat: add --max-scale option

### DIFF
--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -256,7 +256,6 @@ if [ -z "$GAMESCOPECMD" ]; then
 		--default-touch-mode $TOUCH_MODE \
 		--hide-cursor-delay $HIDE_CURSOR_DELAY_MS \
 		--fade-out-duration $FADE_OUT_DURATION_MS \
-		--max-scale $MAX_SCALE \
 		--steam"
 fi
 

--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -169,6 +169,7 @@ if [ -z "$GAMESCOPECMD" ]; then
 	: "${TOUCH_MODE:=4}"
 	: "${HIDE_CURSOR_DELAY_MS:=3000}"
 	: "${FADE_OUT_DURATION_MS:=200}"
+	: "${MAX_SCALE:=2}"
 
 	CURSOR=""
 	if [ -f "$CURSOR_FILE" ]; then
@@ -250,6 +251,7 @@ if [ -z "$GAMESCOPECMD" ]; then
 		--default-touch-mode $TOUCH_MODE \
 		--hide-cursor-delay $HIDE_CURSOR_DELAY_MS \
 		--fade-out-duration $FADE_OUT_DURATION_MS \
+		--max-scale $MAX_SCALE \
 		--steam"
 fi
 

--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -169,7 +169,6 @@ if [ -z "$GAMESCOPECMD" ]; then
 	: "${TOUCH_MODE:=4}"
 	: "${HIDE_CURSOR_DELAY_MS:=3000}"
 	: "${FADE_OUT_DURATION_MS:=200}"
-	: "${MAX_SCALE:=2}"
 
 	CURSOR=""
 	if [ -f "$CURSOR_FILE" ]; then
@@ -222,6 +221,11 @@ if [ -z "$GAMESCOPECMD" ]; then
 	if [ -n "$BACKEND" ] && gamescope_has_option "--backend"; then
 		BACKEND_OPTION="--backend $BACKEND"
 	fi
+	
+	MAX_SCALE_OPTION=""
+	if [ -n "$MAX_SCALE" ] && gamescope_has_option "--max-scale"; then
+		MAX_SCALE_OPTION="--max-scale $MAX_SCALE"
+	fi
 
   HDR_OPTIONS=""
   if [ "$ENABLE_GAMESCOPE_HDR" == "1" ] && [ "$ENABLE_GAMESCOPE_WSI" == "1" ] && gamescope_has_option "--hdr-enabled" && gamescope_has_option "--hdr-itm-enable"; then
@@ -246,6 +250,7 @@ if [ -z "$GAMESCOPECMD" ]; then
 		$USE_ROTATION_SHADER_OPTION \
 		$BACKEND_OPTION \
 		$HDR_OPTIONS \
+		$MAX_SCALE_OPTION \
 		--prefer-output $OUTPUT_CONNECTOR \
 		--xwayland-count $XWAYLAND_COUNT \
 		--default-touch-mode $TOUCH_MODE \


### PR DESCRIPTION
On SteamOS, small windows will scale integer-wise. This affects things like error handlers and simple pre-game launchers.

Adds the Gamescope flag `--max-scale` with a default value of `2` to match SteamOS behavior.

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/b0b73d6b-c887-4f16-8261-4ca3a9ec5aa6" />
