### PR TITLE
replace drm shader rotation with composition rotation

### DIFF
--- a/usr/lib/systemd/user/gamescope-session-plus@.service
+++ b/usr/lib/systemd/user/gamescope-session-plus@.service
@@ -4,6 +4,7 @@ BindsTo=graphical-session.target
 Before=graphical-session.target
 Wants=graphical-session-pre.target
 After=graphical-session-pre.target
+PartOf=gamescope-session.target
 
 [Service]
 ExecStart=/usr/share/gamescope-session-plus/gamescope-session-plus %i

--- a/usr/lib/systemd/user/gamescope-session.target
+++ b/usr/lib/systemd/user/gamescope-session.target
@@ -1,0 +1,2 @@
+[Unit]
+Description=Gamescope Session Target

--- a/usr/share/gamescope-session-plus/device-quirks
+++ b/usr/share/gamescope-session-plus/device-quirks
@@ -30,7 +30,7 @@ fi
 OXP_X1_LIST="ONEXPLAYER X1 i"
 if [[ ":$OXP_X1_LIST:" =~ ":$SYS_ID:"  ]]; then
   PANEL_TYPE=internal
-  USE_ROTATION_SHADER=1
+  FORCE_COMPOSITION_ROTATION=1
   ORIENTATION=left
   CUSTOM_REFRESH_RATES=60,120
 
@@ -63,7 +63,7 @@ fi
 if [[ ":$SYS_ID:" =~ :ONEXPLAYER\ G1\ (A|i): ]]; then
   PANEL_TYPE=internal
   # AMD version has hardware rotation
-  [[ ":$SYS_ID:" =~ ":ONEXPLAYER G1 i:" ]] && USE_ROTATION_SHADER=1
+  [[ ":$SYS_ID:" =~ ":ONEXPLAYER G1 i:" ]] && FORCE_COMPOSITION_ROTATION=1
   ORIENTATION=left
   CUSTOM_REFRESH_RATES=60,144
 

--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -331,7 +331,13 @@ if [ -n "$STEAMCMD" ]; then
 fi
 
 # Start client application
-$CLIENTCMD
+# This is started with switcheroo to match KDE & GNOME behavior for apps with UseAlternativeGPU specified in their desktop file - such as Steam.
+# Switcheroo will add necessary environment arguments to ensure the dGPU on the system is used, if applicable.
+if command -v /usr/bin/switcherooctl >/dev/null; then
+  switcherooctl launch $CLIENTCMD
+else
+  $CLIENTCMD
+fi
 
 if [[ "$SECONDS" -lt "$short_session_duration" ]]; then
 	echo "${CLIENT} failed" >>"$short_session_tracker_file"

--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -334,7 +334,7 @@ fi
 # This is started with switcheroo to match KDE & GNOME behavior for apps with UseAlternativeGPU specified in their desktop file - such as Steam.
 # Switcheroo will add necessary environment arguments to ensure the dGPU on the system is used, if applicable.
 if command -v /usr/bin/switcherooctl >/dev/null; then
-  switcherooctl launch $CLIENTCMD
+  /usr/bin/switcherooctl launch $CLIENTCMD
 else
   $CLIENTCMD
 fi

--- a/usr/share/gamescope-session-plus/gamescope-session-plus
+++ b/usr/share/gamescope-session-plus/gamescope-session-plus
@@ -211,9 +211,9 @@ if [ -z "$GAMESCOPECMD" ]; then
 		CUSTOM_REFRESH_RATES_OPTION="--custom-refresh-rates $CUSTOM_REFRESH_RATES"
 	fi
 
-	USE_ROTATION_SHADER_OPTION=""
-	if [ -n "$USE_ROTATION_SHADER" ] && gamescope_has_option "--use-rotation-shader"; then
-		USE_ROTATION_SHADER_OPTION="--use-rotation-shader $USE_ROTATION_SHADER"
+	FORCE_COMPOSITION_ROTATION_OPTION=""
+	if [ "$FORCE_COMPOSITION_ROTATION" = "1" ] && gamescope_has_option "--force-composition-rotation"; then
+		FORCE_COMPOSITION_ROTATION="--force-composition-rotation"
 	fi
 
 	BACKEND_OPTION=""
@@ -248,7 +248,7 @@ if [ -z "$GAMESCOPECMD" ]; then
 		$ADAPTIVE_SYNC_OPTION \
 		$PANEL_TYPE_OPTION \
 		$CUSTOM_REFRESH_RATES_OPTION \
-		$USE_ROTATION_SHADER_OPTION \
+		$FORCE_COMPOSITION_ROTATION_OPTION \
 		$BACKEND_OPTION \
 		$HDR_OPTIONS \
 		$MAX_SCALE_OPTION \


### PR DESCRIPTION
replaces the old drm shader rotation with the force composition rotation patch that will most likely be merged upstream, marked as draft until ogc/gamescope PR is created